### PR TITLE
Ajoute le logo et harmonise la palette bleue

### DIFF
--- a/INDEX.HTML
+++ b/INDEX.HTML
@@ -8,21 +8,36 @@
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: linear-gradient(135deg, #0f4c75 0%, #3282b8 100%);
             min-height: 100vh; padding: 20px;
         }
         .container { max-width: 1200px; margin: 0 auto; background: #fff; border-radius: 15px; box-shadow: 0 20px 60px rgba(0,0,0,0.3); overflow: hidden; }
-        header { background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%); color: #fff; padding: 40px; text-align: center; }
+        header {
+            background: linear-gradient(135deg, #0f4c75 0%, #3282b8 100%);
+            color: #fff;
+            padding: 40px;
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 18px;
+        }
+        header img {
+            width: 140px;
+            max-width: 50%;
+            height: auto;
+            filter: drop-shadow(0 6px 12px rgba(0,0,0,0.25));
+        }
         header h1 { font-size: 2.5em; margin-bottom: 10px; font-weight: 700; }
         header p { font-size: 1.1em; opacity: 0.95; }
         .intro { padding: 30px 40px; background: #f8f9fa; border-bottom: 3px solid #e9ecef; }
         .intro p { line-height: 1.8; color: #495057; margin-bottom: 15px; }
         .refs { padding: 10px 40px 0 40px; background: #f8f9fa; display:flex; flex-wrap:wrap; gap:10px; }
-        .badge { display:inline-block; background:#667eea; color:#fff; padding:6px 12px; border-radius: 20px; font-size: .85em; }
+        .badge { display:inline-block; background:#2563eb; color:#fff; padding:6px 12px; border-radius: 20px; font-size: .85em; }
         .disciplines { padding: 40px; }
-        .disciplines h2 { color: #2a5298; margin-bottom: 30px; font-size: 1.8em; text-align: center; }
+        .disciplines h2 { color: #1d4ed8; margin-bottom: 30px; font-size: 1.8em; text-align: center; }
         .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; margin-bottom: 30px; }
-        .card { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color:#fff; padding:25px; border-radius:10px; cursor:pointer; transition:.3s; box-shadow: 0 4px 6px rgba(0,0,0,.1); }
+        .card { background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 100%); color:#fff; padding:25px; border-radius:10px; cursor:pointer; transition:.3s; box-shadow: 0 4px 6px rgba(0,0,0,.1); }
         .card:hover { transform: translateY(-5px); box-shadow: 0 8px 15px rgba(0,0,0,.2); }
         .card h3 { font-size:1.2em; margin-bottom:8px; }
         .card p { font-size:.95em; opacity:.9; }
@@ -31,13 +46,13 @@
         .modal { display:none; position:fixed; inset:0; background: rgba(0,0,0,.7); z-index:1000; overflow-y:auto; padding:20px; }
         .modal-content { background:#fff; max-width: 900px; margin: 40px auto; border-radius:15px; box-shadow: 0 20px 60px rgba(0,0,0,.3); animation: slideIn .25s ease; }
         @keyframes slideIn { from{opacity:0; transform: translateY(-50px);} to{opacity:1; transform:none;} }
-        .modal-header { background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%); color:#fff; padding: 30px; border-radius: 15px 15px 0 0; position:relative; }
+        .modal-header { background: linear-gradient(135deg, #0f4c75 0%, #3282b8 100%); color:#fff; padding: 30px; border-radius: 15px 15px 0 0; position:relative; }
         .modal-header h2 { font-size: 1.6em; margin-bottom: 5px; }
         .close { position:absolute; top:20px; right:30px; font-size: 32px; color:#fff; cursor:pointer; line-height:1; transition: transform .2s; }
         .close:hover { transform: scale(1.1); }
         .modal-body { padding: 30px 40px; color:#333; }
         .section { margin-bottom: 26px; }
-        .section h3 { color:#2a5298; margin-bottom: 12px; font-size: 1.25em; border-bottom: 2px solid #e9ecef; padding-bottom: 8px; }
+        .section h3 { color:#1d4ed8; margin-bottom: 12px; font-size: 1.25em; border-bottom: 2px solid #e9ecef; padding-bottom: 8px; }
         .section h4 { color:#495057; margin: 16px 0 8px; font-size: 1.05em; }
         .section p, .section li { line-height: 1.7; color:#495057; margin-bottom: 8px; }
         .section ul { margin-left: 20px; }
@@ -46,6 +61,7 @@
 <body>
 <div class="container">
     <header>
+        <img src="https://i.imgur.com/0YmGlXO.png" alt="Logo du Lycée Français Jacques Prévert" />
         <h1>Projet Local d'Évaluation</h1>
         <p>Lycée Français Jacques Prévert – Saly | 2025‑2026</p>
     </header>


### PR DESCRIPTION
## Summary
- ajoute le logo officiel dans l'en-tête de la page
- remplace les anciens dégradés violets par une palette de bleus cohérente sur l'ensemble de l'interface
- met à jour les composants (cartes, badges, titres et modales) pour refléter la nouvelle identité visuelle

## Testing
- not run (non applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de582893348331a163702dbba8eae3