### PR TITLE
Add evaluation-focused favicon

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1f3b73" />
+      <stop offset="100%" stop-color="#2e5da8" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#bg)" />
+  <path d="M20 18h24a2 2 0 0 1 2 2v24a2 2 0 0 1-2 2H20a2 2 0 0 1-2-2V20a2 2 0 0 1 2-2z" fill="#f7f9ff" />
+  <path d="M24 18v-2a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v2" fill="#d7e2ff" />
+  <path d="M24 34.5l6 6 10-11" fill="none" stroke="#1f6f43" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" />
+  <path d="M24 26h16" stroke="#4a63a7" stroke-linecap="round" stroke-width="3" />
+  <path d="M24 30h12" stroke="#4a63a7" stroke-linecap="round" stroke-width="3" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Projet Local d'Évaluation - LFJP 2025-2026</title>
+    <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
     <link rel="stylesheet" href="assets/css/main.css" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add an SVG favicon illustrating the evaluation theme with a document and checkmark
- reference the new favicon from the site head to display it in browsers

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de5e38b19c8331a0422256172c7a95