### PR TITLE
Soften blue gradient tones

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,7 +1,7 @@
 :root {
-    --primary-dark: #0f4c75;
-    --primary-medium: #3282b8;
-    --accent: #2563eb;
+    --primary-dark: #1d5f8c;
+    --primary-medium: #6cb1de;
+    --accent: #3d7cc9;
     --text-dark: #495057;
     --surface: #ffffff;
     --surface-muted: #f8f9fa;
@@ -106,7 +106,7 @@ header p {
 }
 
 .card {
-    background: linear-gradient(135deg, #1e3a8a 0%, var(--accent) 100%);
+    background: linear-gradient(135deg, #2c5fa7 0%, var(--accent) 100%);
     color: var(--surface);
     padding: 25px;
     border-radius: 10px;


### PR DESCRIPTION
## Summary
- lighten the primary color variables used for the global gradient background
- adjust card gradient to match the softer palette while keeping the gradient effect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de60cc75f08331ac8c42e180a30c52