### PR TITLE
Link reference badges to official resources

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -85,6 +85,7 @@ header p {
     padding: 6px 12px;
     border-radius: 20px;
     font-size: 0.85rem;
+    text-decoration: none;
 }
 
 .disciplines {

--- a/index.html
+++ b/index.html
@@ -20,10 +20,10 @@
         <p>Le PLE précise les modalités d'évaluation en première et terminale avec une double finalité : certificative pour les disciplines prises en compte dans l'obtention du baccalauréat, informative pour l'orientation et l'entrée dans le supérieur.</p>
     </div>
     <div class="refs">
-        <span class="badge">Arrêté 16/07/2018</span>
-        <span class="badge">Note de service 25/08/2025</span>
-        <span class="badge">Banque nationale des sujets</span>
-        <span class="badge">Grilles CECRL</span>
+        <a class="badge" href="https://www.legifrance.gouv.fr/loda/id/JORFTEXT000037202847" target="_blank" rel="noopener noreferrer">Arrêté 16/07/2018</a>
+        <a class="badge" href="https://www.education.gouv.fr/bo/2025/Hebdo32/MENE2523744N" target="_blank" rel="noopener noreferrer">Note de service 25/08/2025</a>
+        <a class="badge" href="https://www.education.gouv.fr/reussir-au-lycee/bns" target="_blank" rel="noopener noreferrer">Banque nationale des sujets</a>
+        <a class="badge" href="https://eduscol.education.fr/880/modalites-d-evaluation-de-langues-au-bac-gt-et-attestation-de-langues?utm_source=chatgpt.com" target="_blank" rel="noopener noreferrer">Grilles CECRL</a>
     </div>
 
     <section class="disciplines" aria-labelledby="disciplines-title">


### PR DESCRIPTION
## Summary
- convert the reference badges into links to the official arrêté, note de service, CECRL guidance, and BNS pages
- ensure the badges retain their styling when used as anchors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6266696c8331ad0963c9361d12c9