### PR TITLE
Add interactive hover animation to reference badges

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -86,6 +86,35 @@ header p {
     border-radius: 20px;
     font-size: 0.85rem;
     text-decoration: none;
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.35s ease, box-shadow 0.35s ease, filter 0.35s ease;
+}
+
+.badge::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: -35%;
+    width: 0;
+    height: 220%;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0));
+    transform: translateY(-50%) rotate(25deg);
+    transition: width 0.45s ease;
+    pointer-events: none;
+}
+
+.badge:hover,
+.badge:focus-visible {
+    transform: translateY(-2px) scale(1.06);
+    box-shadow: 0 8px 18px rgba(61, 124, 201, 0.35);
+    filter: brightness(1.05);
+    outline: none;
+}
+
+.badge:hover::before,
+.badge:focus-visible::before {
+    width: 150%;
 }
 
 .disciplines {


### PR DESCRIPTION
## Summary
- enhance the reference badges with a dynamic hover/focus animation
- add a sheen effect that invites interaction while keeping accessibility in mind

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de63d4ecc08331ba68dbb8443f7192